### PR TITLE
SFCC-8 Reduce API Calls - Billing Model updates

### DIFF
--- a/cartridges/int_stickyio_sfra/cartridge/controllers/Subscriptions.js
+++ b/cartridges/int_stickyio_sfra/cartridge/controllers/Subscriptions.js
@@ -26,11 +26,12 @@ if (stickyioEnabled) {
                 res.json();
                 return next();
             }
-
+            var billingModels = stickyio.getBillingModelsFromStickyio(1, {});
             var ordersResult = SubscriptionHelpers.getSubscriptions(
                 req.currentCustomer,
                 req.querystring,
-                req.locale.id
+                req.locale.id,
+                billingModels
             );
             var subscriptions = ordersResult.subscriptions;
             var filterValues = ordersResult.filterValues;
@@ -52,11 +53,13 @@ if (stickyioEnabled) {
         userLoggedIn.validateLoggedIn,
         function (req, res, next) {
             var SubscriptionHelpers = require('~/cartridge/scripts/subscription/subscriptionHelpers');
-
+            var billingModels = stickyio.getBillingModelsFromStickyio(1, {});
+            
             var ordersResult = SubscriptionHelpers.getSubscriptions(
                 req.currentCustomer,
                 req.querystring,
-                req.locale.id
+                req.locale.id,
+                billingModels
             );
             var subscriptions = ordersResult.subscriptions;
             var filterValues = ordersResult.filterValues;
@@ -95,10 +98,13 @@ if (stickyioEnabled) {
             // and maintains security by only allowing the customer that is currently logged view a subscription if it is owned by an order belonging to that customer
             var SubscriptionHelpers = require('~/cartridge/scripts/subscription/subscriptionHelpers');
 
+            var billingModels = stickyio.getBillingModelsFromStickyio(1, {});
+            
             var ordersResult = SubscriptionHelpers.getSubscriptions(
                 req.currentCustomer,
                 req.querystring,
-                req.locale.id
+                req.locale.id,
+                billingModels
             );
 
             var order;
@@ -106,7 +112,7 @@ if (stickyioEnabled) {
             var currentCustomerNo;
             var subscriptions = ordersResult.subscriptions;
             if (subscriptions.length > 0) {
-                subscription = Object.assign(subscriptions[0], stickyio.getSubscriptionData(subscriptions[0].orderNumbers[0].stickyioOrderNo, subscriptions[0].subscriptionID));
+                subscription = Object.assign(subscriptions[0], stickyio.getSubscriptionData(subscriptions[0].orderNumbers[0].stickyioOrderNo, subscriptions[0].subscriptionID, billingModels));
                 order = OrderMgr.getOrder(subscription.orderNumbers[0].sfccOrderNo, subscription.orderNumbers[0].sfccOrderToken);
                 currentCustomerNo = order.customer.profile.customerNo;
             }

--- a/cartridges/int_stickyio_sfra/cartridge/scripts/stickyio.js
+++ b/cartridges/int_stickyio_sfra/cartridge/scripts/stickyio.js
@@ -2479,7 +2479,7 @@ function getStickyioCustomField(customFields, token) {
             }
         }
     }
-    return  model;
+    return model;
 }
 
 /**

--- a/cartridges/int_stickyio_sfra/cartridge/scripts/stickyio.js
+++ b/cartridges/int_stickyio_sfra/cartridge/scripts/stickyio.js
@@ -2197,7 +2197,7 @@ function updateSubscriptionDetails(orderView) {
  * @param {string} subscriptionID - sticky.io subscriptionID
  * @returns {Object} - Updated orderView object
  */
-function getSubscriptionData(stickyioOrderNumber, subscriptionID) {
+function getSubscriptionData(stickyioOrderNumber, subscriptionID, billingModels) {
     var i;
     var j;
     var stickyioOrderData = {};
@@ -2216,7 +2216,11 @@ function getSubscriptionData(stickyioOrderNumber, subscriptionID) {
                     stickyioOrderData.hold_date = thisProduct.hold_date;
                     stickyioOrderData.recurring_date = Resource.msg('label.subscriptionmanagement.on_hold', 'stickyio', null) + ' ' + stickyioOrderData.hold_date;
                 } else { 
-                    stickyioOrderData.recurring_date = getNextDeliveryDate(stickyioOrderData.stickyioOrderData[thisOrder], thisProduct, thisProduct.recurring_date); 
+                    var billingModel;
+                    if (billingModels) {
+                        billingModel = getBillingModelFromModels(thisProduct.billing_model.id, billingModels);                      
+                    }
+                    stickyioOrderData.recurring_date = getNextDeliveryDate(stickyioOrderData.stickyioOrderData[thisOrder], thisProduct, thisProduct.recurring_date, billingModel); 
                 }
                 stickyioOrderData.billingModels = thisProduct.billing_models;
                 break;
@@ -2454,6 +2458,29 @@ function getStickyioCustomField(customFields, token) {
 
     return customField;
 }
+/**
+ * Get billing model by ID
+ * @param {number} billingModelId - the billing model id to look for
+ * @returns {Object} - the billing model
+ */
+ function getBillingModelFromModels(billingModelId, billingModels) {
+    var model;
+    
+    if (billingModels){
+        var keys = [];
+        keys = Object.keys(billingModels);
+        
+        for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            var thisModel = billingModels[key];
+            if (billingModelId == thisModel.id) {
+                model = thisModel;
+                break;
+            }
+        }
+    }
+    return  model;
+}
 
 /**
  * Get sticky's billing model by ID
@@ -2479,20 +2506,29 @@ function getStickyioCustomField(customFields, token) {
  * @param {number} billingModelId - the id of the billing model
  * @returns {number} - the delivery frequency (in days)
  */
-function getStickyioDeliveryFrequency(billingModelId) {
-    let billingModel = getBillingModelById(billingModelId);
+function getStickyioDeliveryFrequency(billingModelId, billingModel) {
     let frequency = 0;
-
-    if (billingModel) {
-        switch (Number(billingModel.bill_by_type_id)) {
+    if (!billingModel) {
+        //Retrieve individual option if it is not found in the list
+        billingModel = getBillingModelById(billingModelId);
+        if (billingModel) {
+            switch (Number(billingModel.bill_by_type_id)) {
+                case BILLING_MODEL_TYPE_BY_CYCLE:
+                    frequency = Number(billingModel.bill_by_days);
+                    break;
+                default:
+                    frequency = 0;
+            }
+        }
+    } else {
+        switch (Number(billingModel.type.id)) {
             case BILLING_MODEL_TYPE_BY_CYCLE:
-                frequency = Number(billingModel.bill_by_days);
+                frequency = billingModel.frequency;
                 break;
             default:
                 frequency = 0;
         }
     }
-
     return frequency;
 }
 
@@ -2503,7 +2539,7 @@ function getStickyioDeliveryFrequency(billingModelId) {
  * @param {Object} currentDeliveryDate - the current delivery date
  * @returns {string} - the next delivery date
  */
- function getNextDeliveryDate(stickyOrderData, currentProduct, currentDeliveryDate) {
+ function getNextDeliveryDate(stickyOrderData, currentProduct, currentDeliveryDate, billingModel) {
     let nextDeliveryDate = currentDeliveryDate;
     let customerDeliveryDate = getStickyioCustomField(stickyOrderData.custom_fields, 'sfcc_customer_delivery_date');
     let currentCycle = getStickyioCustomField(stickyOrderData.custom_fields, 'sfcc_current_cycle');
@@ -2511,7 +2547,7 @@ function getStickyioDeliveryFrequency(billingModelId) {
     if (customerDeliveryDate && currentCycle) {
         let customerDeliveryDateValue = customerDeliveryDate.values[0].value;
         let currentCycleValue = parseInt(currentCycle.values[0].value, 10);
-        let deliveryFrequency = getStickyioDeliveryFrequency(currentProduct.billing_model.id);
+        let deliveryFrequency = getStickyioDeliveryFrequency(currentProduct.billing_model.id, billingModel);
 
         if (customerDeliveryDateValue.length > 0 && currentCycleValue >= 1 && deliveryFrequency > 0) {
             let date = new Date(customerDeliveryDateValue);
@@ -2557,5 +2593,7 @@ module.exports = {
     getStickyioCustomField: getStickyioCustomField,
     getStickyioDeliveryFrequency: getStickyioDeliveryFrequency,
     getNextDeliveryDate: getNextDeliveryDate,
-    getBillingModelById: getBillingModelById
+    getBillingModelById: getBillingModelById,
+    getBillingModelFromModels: getBillingModelFromModels,
+    getBillingModelsFromStickyio : getBillingModelsFromStickyio
 };

--- a/cartridges/int_stickyio_sfra/cartridge/scripts/subscription/subscriptionHelpers.js
+++ b/cartridges/int_stickyio_sfra/cartridge/scripts/subscription/subscriptionHelpers.js
@@ -57,7 +57,7 @@ function getCustomerID(stickyioCustomFields) {
 * @param {string} locale - the current request's locale id
 * @returns {Object} - orderModel of the current dw order object
 * */
-function getSubscriptions(currentCustomer, querystring, locale) {
+function getSubscriptions(currentCustomer, querystring, locale, billingModels) {
     // get all subscription orders for this user
     var customerID;
     var customerNo = currentCustomer.profile.customerNo;
@@ -212,8 +212,13 @@ function getSubscriptions(currentCustomer, querystring, locale) {
                     var thisProduct = thisStickyOrderData.products[j];
                     var thisProductSubscriptionID = thisProduct.subscription_id;
                     if (assertSubscriptionID(thisProductSubscriptionID, thisStickyioOrderNo) && customerID === getCustomerID(thisStickyOrderData.custom_fields)) { // make sure this stickyOrderNumber is under the subscriptionID key and belongs to the current customer. If not, toss the entire subscriptionID from subscriptions (old order in SFCC from testing sharing same order number as new order)
+                        var billingModel;
+                        if (billingModels) {
+                            billingModel = stickyio.getBillingModelFromModels(thisProduct.billing_model.id, billingModels);
+                        }
+                        
                         validSubscriptionIDs[thisProductSubscriptionID] = {
-                            nextRecurring: stickyio.getNextDeliveryDate(thisStickyOrderData, thisProduct, thisProduct.recurring_date),
+                            nextRecurring: stickyio.getNextDeliveryDate(thisStickyOrderData, thisProduct, thisProduct.recurring_date, billingModel),
                             statusText: Resource.msg('label.subscriptionmanagement.active', 'stickyio', null),
                             status: 'active'
                         };


### PR DESCRIPTION
Modified code to retrieve and use billing model list instead of retrieving individual billing models several times which was causing API limit quota violations.