### PR TITLE
SFCC-25 - Cancellation in sticky leads to pause / resume in merchant's member portal

### DIFF
--- a/cartridges/int_stickyio_sfra/cartridge/scripts/subscription/subscriptionHelpers.js
+++ b/cartridges/int_stickyio_sfra/cartridge/scripts/subscription/subscriptionHelpers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const HOLD_TYPE_CANCEL = 'user';
+
 var OrderMgr = require('dw/order/OrderMgr');
 var Order = require('dw/order/Order');
 var Resource = require('dw/web/Resource');
@@ -223,8 +225,13 @@ function getSubscriptions(currentCustomer, querystring, locale, billingModels) {
                             status: 'active'
                         };
                         if (thisProduct.on_hold === '1') {
-                            validSubscriptionIDs[thisProductSubscriptionID].statusText = Resource.msg('label.subscriptionmanagement.on_hold', 'stickyio', null);
-                            validSubscriptionIDs[thisProductSubscriptionID].status = 'hold';
+                            if (thisProduct.hold_type.toLowerCase() == HOLD_TYPE_CANCEL) {
+                                validSubscriptionIDs[thisProductSubscriptionID].statusText = Resource.msg('label.subscriptionmanagement.canceled', 'stickyio', null);
+                                validSubscriptionIDs[thisProductSubscriptionID].status = 'canceled';
+                            } else {
+                                validSubscriptionIDs[thisProductSubscriptionID].statusText = Resource.msg('label.subscriptionmanagement.on_hold', 'stickyio', null);
+                                validSubscriptionIDs[thisProductSubscriptionID].status = 'hold';
+                            }
                         }
                         if (thisProduct.on_hold === '0' && thisProduct.is_recurring === '0') { // logic to determine if subscription is complete
                             delete (validSubscriptionIDs[thisProductSubscriptionID].nextRecurring);

--- a/cartridges/int_stickyio_sfra/cartridge/templates/resources/stickyio.properties
+++ b/cartridges/int_stickyio_sfra/cartridge/templates/resources/stickyio.properties
@@ -3,6 +3,7 @@ label.subscriptionmanagement.orderheader=Subscriptions
 label.subscriptionmanagement.title=Subscription Management
 label.subscriptionmanagement.recurring_date=Next Recurring Date
 label.subscriptionmanagement.on_hold=ON HOLD
+label.subscriptionmanagement.canceled=Canceled
 label.subscriptionmanagement.active=Active
 label.subscriptionmanagement.complete=Complete
 label.subscriptionmanagement.resumelabel=Resume Subscription Options


### PR DESCRIPTION
Display ‘canceled’ in the status section if hold_type_id = 2 (hold_type = 'User' on the SFCC side).